### PR TITLE
Fix - Force ipfs-unixfs@6.0.6 resolution to keep using node14

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   ],
   "author": "SubQuery Network",
   "license": "MIT",
+  "resolutions": {
+    "ipfs-unixfs": "6.0.6"
+  },
   "devDependencies": {
     "@polkadot/api": "^8",
     "@subql/types": "latest",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "subql build",
     "prepack": "rm -rf dist && npm build",
     "test": "jest",
-    "codegen": "./node_modules/.bin/subql codegen"
+    "codegen": "./node_modules/.bin/subql codegen",
+    "start:docker": "docker-compose pull && docker-compose up --remove-orphans"
   },
   "homepage": "https://github.com/subquery/moonbeam-alpha-subql-starter",
   "repository": "github:subquery/moonbeam-alpha-subql-starter",
@@ -16,7 +17,7 @@
     "schema.graphql",
     "project.yaml"
   ],
-  "author": "SubQuery Network",
+  "author": "SubQuery Team",
   "license": "MIT",
   "resolutions": {
     "ipfs-unixfs": "6.0.6"


### PR DESCRIPTION
If we want project to keep using `node14`, this dependency gets in the way with their latest version. As the dependency is actually `^6.0.3`, the `6.0.6` is good enough.